### PR TITLE
Added Logout Button to User Menu

### DIFF
--- a/src/components/menus/UserMenu/Menu/index.tsx
+++ b/src/components/menus/UserMenu/Menu/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from 'react';
 import {
-  Box,
   IconButton,
   Popover,
   List,
@@ -8,20 +7,37 @@ import {
   ListItemText,
   ListItemButton
 } from '@mui/material';
+import { useMutation, useQueryClient } from 'react-query';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'; 
-import UserForm from '../../forms/UserForm';
-import CardModal from '../../modal/CardModal';
+import UserForm from '../../../forms/UserForm';
+import CardModal from '../../../modal/CardModal';
+import axios from 'axios';
 
-interface MenuButtonProps {
+interface MenuProps {
   user: any;
 };
 
-const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
+const Menu: React.FC<MenuProps> = ({ user }) => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const [accountSettingsModalOpen, setAccountSettingsModalOpen] = useState<boolean>(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const queryClient = useQueryClient();
 
   const toggleMenuOpen = () => setMenuOpen((prev) => !prev);
+
+  const { mutate: logout } = useMutation(
+    () => axios.get(
+      `${process.env.REACT_APP_API_URL}/auth/logout`,
+      {
+        withCredentials: true
+      }
+    ),
+    {
+      onSuccess: () => {
+        queryClient.setQueryData('currentUser', undefined);
+      }
+    }
+  );
 
   const MenuPopover = () => {
     return (
@@ -38,7 +54,7 @@ const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
           vertical: 'top',
           horizontal: 'right',
         }}
-        data-testid="MenuButton-MenuPopover"
+        data-testid="UserMenu-MenuPopover"
       >
         <List>
           <ListItem
@@ -46,10 +62,22 @@ const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
           >
             <ListItemButton
               onClick={() => setAccountSettingsModalOpen(true)}
-              data-testid="MenuButton-AccountSettingsButton"
+              data-testid="UserMenu-AccountSettingsButton"
             >
               <ListItemText
                 primary="Account Settings"
+              />
+            </ListItemButton>
+          </ListItem>
+          <ListItem
+            disablePadding
+          >
+            <ListItemButton
+              onClick={() => logout()}
+              data-testid="UserMenu-LogoutButton"
+            >
+              <ListItemText
+                primary="Logout"
               />
             </ListItemButton>
           </ListItem>
@@ -70,7 +98,7 @@ const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
             paddingBottom: '15px'
           }
         }}
-        data-testid='MenuButton-AccountSettingsModal'
+        data-testid='UserMenu-AccountSettingsModal'
       >
         <UserForm
           user={user}
@@ -84,7 +112,7 @@ const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
       <IconButton
         ref={buttonRef}
         onClick={toggleMenuOpen}
-        data-testid="MenuButton-MenuToggleButton"
+        data-testid="UserMenu-MenuToggleButton"
       >
         <AccountCircleIcon />
       </IconButton>
@@ -94,4 +122,4 @@ const MenuButton: React.FC<MenuButtonProps> = ({ user }) => {
   );
 };
 
-export default MenuButton;
+export default Menu;

--- a/src/components/menus/UserMenu/index.tsx
+++ b/src/components/menus/UserMenu/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoginButton from './LoginButton';
-import MenuButton from './MenuButton';
+import Menu from './Menu';
 import {
   Box
 } from '@mui/material';
@@ -15,7 +15,7 @@ const UserMenu: React.FC<UserMenuProps> = ({ user }) => {
       data-testid="UserMenu-ButtonContainer"
     >
       { user  
-        ? <MenuButton user={user} />
+        ? <Menu user={user} />
         : <LoginButton />
       }
     </Box>

--- a/src/stories/menus/UserMenu.stories.tsx
+++ b/src/stories/menus/UserMenu.stories.tsx
@@ -123,12 +123,14 @@ export const MenuTest: Story = {
     await waitFor(() => {
       expect(screen.getByTestId("MenuButton-MenuPopover")).toBeInTheDocument();
       expect(screen.getByTestId("MenuButton-AccountSettingsButton")).toBeInTheDocument();
+      expect(screen.queryByTestId("MenuButton-LogoutButton")).toBeInTheDocument();
     });
 
     await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
     await waitFor(() => {
       expect(screen.queryByTestId("MenuButton-MenuPopover")).not.toBeInTheDocument();
       expect(screen.queryByTestId("MenuButton-AccountSettingsButton")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("MenuButton-LogoutButton")).not.toBeInTheDocument();
     });
   }
 };
@@ -162,6 +164,37 @@ export const AccountSettingsModalTest: Story = {
       expect(screen.getByTestId("UserForm-FormContainer")).toBeInTheDocument();
       expect(screen.getByTestId("UserForm-DisplayNameText")).toBeInTheDocument();
       expect(screen.getByTestId("UserForm-EditDisplayNameButton")).toBeInTheDocument();
+    });
+  }
+};
+
+export const LogoutTest: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        fetchUser: [createUserFetchHandler(200, [mockUser])],
+        deleteUser: [createUserDeleteHandler(200)]
+      }
+    }
+  },
+  play: async () => {
+    expect(screen.getByTestId("UserMenu-ButtonContainer")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("LoginButton-Button")).not.toBeInTheDocument();
+      expect(screen.getByTestId("MenuButton-MenuToggleButton")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
+    await waitFor(() => {
+      expect(screen.getByTestId("MenuButton-MenuPopover")).toBeInTheDocument();
+      expect(screen.queryByTestId("MenuButton-LogoutButton")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId("MenuButton-LogoutButton"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("MenuButton-MenuPopover")).not.toBeInTheDocument();
+      expect(screen.getByTestId("LoginButton-Button")).toBeInTheDocument();
     });
   }
 };

--- a/src/stories/menus/UserMenu.stories.tsx
+++ b/src/stories/menus/UserMenu.stories.tsx
@@ -2,7 +2,11 @@ import { userEvent, waitFor, screen } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
-import { createUserDeleteHandler, createUserFetchHandler } from '../util/mswHandlers';
+import {
+  createUserDeleteHandler,
+  createUserFetchHandler,
+  createLogoutHandler
+} from '../util/mswHandlers';
 import axios from 'axios';
 import UserMenu from '../../components/menus/UserMenu';
 
@@ -66,7 +70,8 @@ export const LoggedIn: Story = {
     msw: {
       handlers: {
         fetchUser: [createUserFetchHandler(200, [mockUser])],
-        deleteUser: [createUserDeleteHandler(200)]
+        deleteUser: [createUserDeleteHandler(200)],
+        logout: [createLogoutHandler(200)]
       }
     }
   }
@@ -78,7 +83,7 @@ export const NotLoggedInTest: Story = {
     expect(screen.getByTestId("LoginButton-Button")).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.queryByTestId("MenuButton-MenuToggleButton")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-MenuToggleButton")).not.toBeInTheDocument();
     });
   }
 };
@@ -97,7 +102,7 @@ export const LoggedInTest: Story = {
 
     await waitFor(() => {
       expect(screen.queryByTestId("LoginButton-Button")).not.toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-MenuToggleButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuToggleButton")).toBeInTheDocument();
     });
   }
 };
@@ -116,21 +121,21 @@ export const MenuTest: Story = {
 
     await waitFor(() => {
       expect(screen.queryByTestId("LoginButton-Button")).not.toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-MenuToggleButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuToggleButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-MenuToggleButton"));
     await waitFor(() => {
-      expect(screen.getByTestId("MenuButton-MenuPopover")).toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-AccountSettingsButton")).toBeInTheDocument();
-      expect(screen.queryByTestId("MenuButton-LogoutButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuPopover")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-AccountSettingsButton")).toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-LogoutButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-MenuToggleButton"));
     await waitFor(() => {
-      expect(screen.queryByTestId("MenuButton-MenuPopover")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("MenuButton-AccountSettingsButton")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("MenuButton-LogoutButton")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-MenuPopover")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-AccountSettingsButton")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-LogoutButton")).not.toBeInTheDocument();
     });
   }
 };
@@ -149,18 +154,18 @@ export const AccountSettingsModalTest: Story = {
 
     await waitFor(() => {
       expect(screen.queryByTestId("LoginButton-Button")).not.toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-MenuToggleButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuToggleButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-MenuToggleButton"));
     await waitFor(() => {
-      expect(screen.getByTestId("MenuButton-MenuPopover")).toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-AccountSettingsButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuPopover")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-AccountSettingsButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-AccountSettingsButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-AccountSettingsButton"));
     await waitFor(() => {
-      expect(screen.getByTestId("MenuButton-AccountSettingsModal")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-AccountSettingsModal")).toBeInTheDocument();
       expect(screen.getByTestId("UserForm-FormContainer")).toBeInTheDocument();
       expect(screen.getByTestId("UserForm-DisplayNameText")).toBeInTheDocument();
       expect(screen.getByTestId("UserForm-EditDisplayNameButton")).toBeInTheDocument();
@@ -173,7 +178,8 @@ export const LogoutTest: Story = {
     msw: {
       handlers: {
         fetchUser: [createUserFetchHandler(200, [mockUser])],
-        deleteUser: [createUserDeleteHandler(200)]
+        deleteUser: [createUserDeleteHandler(200)],
+        logout: [createLogoutHandler(200)]
       }
     }
   },
@@ -182,18 +188,18 @@ export const LogoutTest: Story = {
 
     await waitFor(() => {
       expect(screen.queryByTestId("LoginButton-Button")).not.toBeInTheDocument();
-      expect(screen.getByTestId("MenuButton-MenuToggleButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuToggleButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-MenuToggleButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-MenuToggleButton"));
     await waitFor(() => {
-      expect(screen.getByTestId("MenuButton-MenuPopover")).toBeInTheDocument();
-      expect(screen.queryByTestId("MenuButton-LogoutButton")).toBeInTheDocument();
+      expect(screen.getByTestId("UserMenu-MenuPopover")).toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-LogoutButton")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByTestId("MenuButton-LogoutButton"));
+    await userEvent.click(screen.getByTestId("UserMenu-LogoutButton"));
     await waitFor(() => {
-      expect(screen.queryByTestId("MenuButton-MenuPopover")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("UserMenu-MenuPopover")).not.toBeInTheDocument();
       expect(screen.getByTestId("LoginButton-Button")).toBeInTheDocument();
     });
   }

--- a/src/stories/util/mswHandlers.ts
+++ b/src/stories/util/mswHandlers.ts
@@ -1,6 +1,18 @@
 import { PeliasGeoJSONFeature } from '@stadiamaps/api';
 import { rest } from 'msw';
 
+// Auth endpoints
+export const createLogoutHandler = (status: number) => {
+  return rest.get(
+    /^.+\/auth\/logout$/,
+    (_req, res, ctx) => {
+      return res(
+        ctx.status(status),
+      );
+    }
+  );
+};
+
 // User endpoints
 export const createUserFetchHandler = (status: number, users=[{}]) => {
   let callCount = -1;


### PR DESCRIPTION
- Implemented a "Logout" button that calls the `/auth/logout` route on the backend to terminate the user's session and sets the cached user to `undefined` upon success.
- Updated tests for updated behavior.