### PR TITLE
 Prevent Modal Close on Backdrop Click

### DIFF
--- a/src/components/modal/CardModal.tsx
+++ b/src/components/modal/CardModal.tsx
@@ -22,6 +22,13 @@ const CardModal: React.FC<ModalProps & CardModalProps> = (props) => {
         pointerEvents: "auto",
         overflow: "auto"
       }}
+      slotProps={{
+        backdrop: {
+          sx: {
+            pointerEvents: "none"
+          }
+        }
+      }}
     >
       <Card 
         {...cardProps}


### PR DESCRIPTION
Solves #50 

Disabled pointer events on the backdrop of the CardModal component to prevent closing the the modal via backdrop click.