### PR TITLE
Move state to context

### DIFF
--- a/src/components/MapUIOverlay/index.tsx
+++ b/src/components/MapUIOverlay/index.tsx
@@ -5,28 +5,26 @@ import ExperienceForm from '../forms/ExperienceForm';
 import LocationSearch from '../form-elements/locationSearch';
 import BugReportForm from '../forms/BugReportForm';
 import { PeliasGeoJSONFeature } from '@stadiamaps/api';
+import { useLandingPageContext } from '../../contexts/LandingPageContext';
 
 interface MapUIOverlayProps {
   redirectToLogin: () => void;
-  user: any;
-  setBbox: React.Dispatch<String | null>;
 };
 
 const MapUIOverlay: React.FC<MapUIOverlayProps> = ({
-  redirectToLogin,
-  user,
-  setBbox
+  redirectToLogin
 }) => {
   const [newExperienceModalOpen, setNewExperienceModalOpen] = useState<boolean>(false);
   const [bugReportModalOpen, setBugReportModalOpen] = useState<boolean>(false);
   const [searchBarLocation, setSearchBarLocation] = useState<PeliasGeoJSONFeature | null>(null);
+  const context = useLandingPageContext();
 
   const toggleNewExperienceModal = () => {
     setNewExperienceModalOpen((prev) => !prev);
   };
 
   const handleCreateExperienceButtonClick = () => {
-    if (user) {
+    if (context.user) {
       toggleNewExperienceModal();
       return;
     }
@@ -35,7 +33,7 @@ const MapUIOverlay: React.FC<MapUIOverlayProps> = ({
   }
 
   const handleLocationSelection = (location: PeliasGeoJSONFeature) => {
-    setBbox(location.bbox?.join(",") || null);
+    context.setBbox(location.bbox?.join(",") || null);
     setSearchBarLocation(location);
   };
 
@@ -68,7 +66,7 @@ const MapUIOverlay: React.FC<MapUIOverlayProps> = ({
       >
         <ExperienceForm
           mode="create"
-          user={user}
+          user={context.user}
         />
       </CardModal>
       <CardModal
@@ -145,7 +143,7 @@ const MapUIOverlay: React.FC<MapUIOverlayProps> = ({
             }}
             onClick={handleCreateExperienceButtonClick}
             data-testid={
-              user
+              context.user
                 ? "MapUIOverlay-CreateExperienceButton-LoggedIn"
                 : "MapUIOverlay-CreateExperienceButton-LoggedOut"
             }

--- a/src/contexts/LandingPageContext.tsx
+++ b/src/contexts/LandingPageContext.tsx
@@ -1,0 +1,100 @@
+import React, { createContext, useState, useContext, useEffect } from 'react';
+import { Experience } from '../types/experience';
+import { useMutation, useQuery, useQueryClient, UseMutationResult } from 'react-query';
+import experiencesRequest from '../api/experiences.request';
+import usersRequest from '../api/users.request';
+import useFetchExperiencesByBbox from '../api/queries/fetchExperiencesByBbox';
+
+interface LandingPageContextType {
+  bbox: string | null;
+  setBbox: React.Dispatch<React.SetStateAction<string | null>>;
+  selectedExperience: Experience | null;
+  setSelectedExperience: React.Dispatch<React.SetStateAction<Experience | null>>;
+  editModalOpen: boolean;
+  setEditModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  deleteModalOpen: boolean;
+  setDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  sidebarOpen: boolean;
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  experiences: Experience[] | undefined;
+  setExperiences: React.Dispatch<React.SetStateAction<Experience[]>>;
+  fetchNextPage: () => void;
+  hasNextPage: boolean | undefined;
+  user: any;
+  deleteExperience: UseMutationResult<void, any, void, unknown>;
+}
+
+const LandingPageContext = createContext<LandingPageContextType | undefined>(undefined);
+
+export const useLandingPageContext = () => {
+  const context = useContext(LandingPageContext);
+
+  if (!context) throw new Error("useLandingPageContext must be used within a LandingPageProvider");
+
+  return context;
+}
+
+interface LandingPageContextProviderProps {
+  children: React.ReactNode;
+}
+
+export const LandingPageContextProvider: React.FC<LandingPageContextProviderProps> = ({ children }) => {
+  const queryClient = useQueryClient();
+  const [bbox, setBbox] = useState<string | null>(null);
+  const [selectedExperience, setSelectedExperience] = useState<Experience | null>(null);
+  const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState<boolean>(false);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+  const { data: user } = useQuery("currentUser", async () => {
+    return await usersRequest.fetchData();
+  });
+
+  const {
+    experiences,
+    setExperiences,
+    fetchNextPage,
+    hasNextPage
+  } = useFetchExperiencesByBbox(bbox);
+
+  const deleteExperience = useMutation(async () => {
+    await experiencesRequest.delete(selectedExperience?._id);
+  }, {
+    onSuccess: async () => {
+      await queryClient.cancelQueries(["experiences", bbox]);
+
+      setExperiences(experiences.filter((experience: Experience) => {
+        return experience._id !== selectedExperience?._id
+      }));
+      setDeleteModalOpen(false);
+      setSelectedExperience(null);
+    },
+    onError: (err: any) => {
+      console.error(`Unable to delete experience: ${err}`);
+    }
+  });  
+
+  return (
+    <LandingPageContext.Provider
+      value={{
+        bbox,
+        setBbox,
+        selectedExperience,
+        setSelectedExperience,
+        editModalOpen,
+        setEditModalOpen,
+        deleteModalOpen,
+        setDeleteModalOpen,
+        sidebarOpen,
+        setSidebarOpen,
+        experiences,
+        setExperiences,
+        fetchNextPage,
+        hasNextPage,
+        user,
+        deleteExperience
+      }}
+    >
+      {children}
+    </LandingPageContext.Provider>
+  );
+}

--- a/src/pages/landingPage/index.tsx
+++ b/src/pages/landingPage/index.tsx
@@ -3,52 +3,48 @@ import ExperienceMap from '../../shared/components/ExperienceMap';
 import SideDrawer from '../../shared/components/side-drawer/SideDrawer';
 import MapUIOverlay from '../../components/MapUIOverlay';
 import { redirectToLogin } from '../../api/helpers';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
-import useFetchExperiencesByBbox from '../../api/queries/fetchExperiencesByBbox';
-import { Experience } from '../../types/experience';
 import EditExperienceModal from '../../shared/components/side-drawer/EditExperienceModal';
 import DeleteExperienceModal from '../../shared/components/side-drawer/DeleteExperienceModal';
-import usersRequest from '../../api/users.request';
-import experiencesRequest from '../../api/experiences.request';
 import { Box } from '@mui/material';
+import { LandingPageContextProvider } from '../../contexts/LandingPageContext';
 
 const LandingPage: React.FC = () => {
   const defaultLocation = [38.9072, 139.69222];
   const defaultZoom = 6;
-  const queryClient = useQueryClient();
   const [userLocation, setUserLocation] = useState<Number[] | null>(null);
-  const [bbox, setBbox] = useState<String | null>(null);
-  const [selectedExperience, setSelectedExperience] = useState<Experience | null>(null);
-  const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState<boolean>(false);
-  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
-  const {
-    experiences,
-    setExperiences,
-    fetchNextPage,
-    hasNextPage
-  } = useFetchExperiencesByBbox(bbox);
+  // const queryClient = useQueryClient();
+  // const [bbox, setBbox] = useState<String | null>(null);
+  // const [selectedExperience, setSelectedExperience] = useState<Experience | null>(null);
+  // const [editModalOpen, setEditModalOpen] = useState<boolean>(false);
+  // const [deleteModalOpen, setDeleteModalOpen] = useState<boolean>(false);
+  // const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+  // const {
+  //   experiences,
+  //   setExperiences,
+  //   fetchNextPage,
+  //   hasNextPage
+  // } = useFetchExperiencesByBbox(bbox);
 
-  const { data: user } = useQuery("currentUser", async () => {
-    return await usersRequest.fetchData();
-  });
+  // const { data: user } = useQuery("currentUser", async () => {
+  //   return await usersRequest.fetchData();
+  // });
 
-  const deleteExperience = useMutation(async () => {
-    await experiencesRequest.delete(selectedExperience?._id);
-  }, {
-    onSuccess: async () => {
-      await queryClient.cancelQueries(["experiences", bbox]);
+  // const deleteExperience = useMutation(async () => {
+  //   await experiencesRequest.delete(selectedExperience?._id);
+  // }, {
+  //   onSuccess: async () => {
+  //     await queryClient.cancelQueries(["experiences", bbox]);
 
-      setExperiences(experiences.filter((experience: Experience) => {
-        return experience._id !== selectedExperience?._id
-      }));
-      setDeleteModalOpen(false);
-      setSelectedExperience(null);
-    },
-    onError: (err: any) => {
-      console.error(`Unable to delete experience: ${err}`);
-    }
-  });
+  //     setExperiences(experiences.filter((experience: Experience) => {
+  //       return experience._id !== selectedExperience?._id
+  //     }));
+  //     setDeleteModalOpen(false);
+  //     setSelectedExperience(null);
+  //   },
+  //   onError: (err: any) => {
+  //     console.error(`Unable to delete experience: ${err}`);
+  //   }
+  // });
 
   const getUserLocation = () => {
     if (navigator.geolocation) {
@@ -67,53 +63,25 @@ const LandingPage: React.FC = () => {
   }, []);
   
   return (
-    <Box
-      sx={{
-        width: "100vw"
-      }}
-    >
-      <MapUIOverlay
-        redirectToLogin={redirectToLogin}
-        user={user}
-        setBbox={setBbox}  
-      />
-      <SideDrawer
-        experiences={experiences}
-        selectedExperience={selectedExperience}
-        setSelectedExperience={setSelectedExperience}
-        hasNextPage={hasNextPage}
-        fetchNextPage={fetchNextPage}
-        setEditModalOpen={setEditModalOpen}
-        setDeleteModalOpen={setDeleteModalOpen}
-        sidebarOpen={sidebarOpen}
-        setSidebarOpen={setSidebarOpen}
-      />
-      <ExperienceMap
-        experiences={experiences}
-        defaultLocation={defaultLocation}
-        defaultZoom={defaultZoom}
-        userLocation={userLocation}
-        bbox={bbox}
-        setBbox={setBbox}
-        setSelectedExperience={setSelectedExperience}
-        setSidebarOpen={setSidebarOpen}
-      />
-      <EditExperienceModal
-        open={editModalOpen}
-        onClose={() => setEditModalOpen(false)}
-        user={user}
-        experience={selectedExperience as Experience}
-        setExperiences={setExperiences}
-        setSelectedExperience={setSelectedExperience}
-      />
-      <DeleteExperienceModal
-        open={deleteModalOpen}
-        onClose={() => setDeleteModalOpen(false)}
-        onDelete={() => deleteExperience.mutate()}
-        deleteError={`${deleteExperience.error}`}
-        processingDeletion={deleteExperience.isLoading}
-      />
-    </Box>
+    <LandingPageContextProvider>
+      <Box
+        sx={{
+          width: "100vw"
+        }}
+      >
+        <MapUIOverlay
+          redirectToLogin={redirectToLogin}
+        />
+        <SideDrawer />
+        <ExperienceMap
+          defaultLocation={defaultLocation}
+          defaultZoom={defaultZoom}
+          userLocation={userLocation}
+        />
+        <EditExperienceModal />
+        <DeleteExperienceModal />
+      </Box>
+    </LandingPageContextProvider>
   )
 }
 

--- a/src/pages/landingPage/reactionBar.tsx/index.tsx
+++ b/src/pages/landingPage/reactionBar.tsx/index.tsx
@@ -87,7 +87,13 @@ const ReactionBar: React.FC<ReactionBarProps> = ({
 
   return (
       <div className={classes.popupGroup}>
-        <div>
+        <div
+          style={{cursor: "pointer"}}
+          onClick={() => {
+            setSelectedExperience(experience);
+            setSidebarOpen(true);
+          }}
+        >
           <div className={classes.experienceTitle}>
           {experience.title}
           </div>

--- a/src/pages/landingPage/reactionBar.tsx/index.tsx
+++ b/src/pages/landingPage/reactionBar.tsx/index.tsx
@@ -1,37 +1,36 @@
 import React, { useState, useEffect } from 'react';
 import reactionsRequest from '../../../api/reactions.request';
-import usersRequest from '../../../api/users.request';
 import { useQuery } from 'react-query';
-import fetchCurrentUser from '../../../api/queries/fetchCurrentUser';
-import { Experience } from '../../../types/experience';
+import { useLandingPageContext } from '../../../contexts/LandingPageContext';
 
 import ThanksForSharing from '../../../assets/reactionIcons/thanksForSharing';
 import MeToo from '../../../assets/reactionIcons/meToo';
 import WillTry from '../../../assets/reactionIcons/willTry';
 import useStyles from './styles';
+import { Experience } from '../../../types/experience';
 
 interface ReactionBarProps {
   experience: Experience;
-  setSelectedExperience: React.Dispatch<Experience | null>;
-  setSidebarOpen: React.Dispatch<boolean>;
 }
 
 const ReactionBar: React.FC<ReactionBarProps> = ({
-  experience,
-  setSelectedExperience,
-  setSidebarOpen
+  experience
 }) => {
   const classes = useStyles();
-  const { data: user, error } = fetchCurrentUser();
+  const {
+    user,
+    setSelectedExperience,
+    setSidebarOpen
+  } = useLandingPageContext();
 
   const [selectedReaction, setSelectedReaction] = useState({
       meToo: false,
       thanksForSharing: false,
       willTry: false
-  })
+  });
 
   const { data: reactions } = useQuery(["reactions", experience._id.toString()], async() => {
-      return await reactionsRequest.getByUserId({ experienceId: experience["_id"], userId: user["_id"] })
+      return await reactionsRequest.getByUserId({ experienceId: experience._id, userId: user["_id"] })
   });
 
   useEffect(() => {
@@ -86,35 +85,24 @@ const ReactionBar: React.FC<ReactionBarProps> = ({
       }
   };
 
-  const handleSelectExperience = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    e.stopPropagation();
-    setSelectedExperience(experience);
-    setSidebarOpen(true);
-  };
-
   return (
       <div className={classes.popupGroup}>
-        <div
-          style={{
-            cursor: "pointer"
-          }}
-          onClick={handleSelectExperience}
-        >
+        <div>
           <div className={classes.experienceTitle}>
-              {experience.title}
+          {experience.title}
           </div>
           <div className={classes.experienceImageGroup}>
-              <img src={experience.foodPhotoUrl} alt={experience.title} className={classes.experienceImage} />
+          <img src={experience.foodPhotoUrl} alt={experience.title} className={classes.experienceImage} />
           </div>
         </div>
         {user && <div className={classes.reactionGroup}>
-            <div id="meToo" className={classes.meToo} title='Me Too' data-experience={experience["_id"]} onClick={handleReaction}>
+        <div id="meToo" className={classes.meToo} title='Me Too' data-experience={experience._id} onClick={handleReaction}>
                 <MeToo/>
             </div>
-            <div id="thanksForSharing" className={classes.thanksForSharing} title='Thanks for sharing' data-experience={experience["_id"]} onClick={handleReaction}>
+        <div id="thanksForSharing" className={classes.thanksForSharing} title='Thanks for sharing' data-experience={experience._id} onClick={handleReaction}>
                 <ThanksForSharing />
             </div>
-            <div id="willTry" className={classes.willTry} title='Will try' data-experience={experience["_id"]} onClick={handleReaction}>
+        <div id="willTry" className={classes.willTry} title='Will try' data-experience={experience._id} onClick={handleReaction}>
                 <WillTry />
             </div>
         </div>}

--- a/src/shared/components/ExperienceMap/index.js
+++ b/src/shared/components/ExperienceMap/index.js
@@ -9,6 +9,7 @@ import L from 'leaflet';
 import MarkerClusterGroup from "react-leaflet-cluster";
 import LeafletTileLayer from './leafletTileLayer.tsx';
 import chefHatIconImage from "../../../assets/chef-hat-icon.png";
+import { useLandingPageContext } from "../../../contexts/LandingPageContext";
 
 const chefHatIcon = new L.Icon({
   iconUrl: chefHatIconImage,
@@ -23,17 +24,19 @@ const chefHatIcon = new L.Icon({
 });
 
 const ExperienceMap = ({
-  experiences,
   defaultLocation,
   defaultZoom,
-  userLocation,
-  bbox,
-  setBbox,
-  setSelectedExperience,
-  setSidebarOpen
-}) => {  
+  userLocation
+}) => {
   const classes = useStyles()
   const [movedToUser, setMovedToUser] = useState(false);
+  const {
+    experiences,
+    bbox,
+    setBbox,
+    setSelectedExperience,
+    setSidebarOpen
+  } = useLandingPageContext();
 
   const updateBbox = (bounds) => { 
     setBbox(bounds.toBBoxString());
@@ -101,18 +104,14 @@ const ExperienceMap = ({
           url="https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}{r}.png"
         />
         <MarkerClusterGroup>
-          {experiences && experiences.map((experience, index) => (
+          {experiences && experiences.map((experience) => (
             <Marker
-              key={experience['_id']}
+              key={experience._id}
               icon={chefHatIcon}
               position={[experience.place.location.coordinates[1], experience.place.location.coordinates[0]]}
             >
               <Popup>
-                <ReactionBar
-                  experience={experience}
-                  setSelectedExperience={setSelectedExperience}
-                  setSidebarOpen={setSidebarOpen}
-                />
+                <ReactionBar experience={experience} />
               </Popup>
             </Marker>
           ))}

--- a/src/shared/components/side-drawer/DeleteExperienceModal.tsx
+++ b/src/shared/components/side-drawer/DeleteExperienceModal.tsx
@@ -7,25 +7,21 @@ import {
   Box,
   Button
 } from '@mui/material';
+import { useLandingPageContext } from '../../../contexts/LandingPageContext';
 
-interface DeleteExperienceModalProps {
-  open: boolean,
-  onClose: () => void;
-  onDelete: () => void;
-  deleteError: string;
-  processingDeletion: boolean;
-};
+const DeleteExperienceModal: React.FC = () => {
+  const {
+    deleteModalOpen,
+    deleteExperience,
+    setDeleteModalOpen
+  } = useLandingPageContext();
+  const deleteError = `${deleteExperience.error}`;
+  const onClose = () => setDeleteModalOpen(false);
+  const onDelete = () => deleteExperience.mutate();
 
-const DeleteExperienceModal: React.FC<DeleteExperienceModalProps> = ({
-  open,
-  onClose,
-  onDelete,
-  deleteError,
-  processingDeletion
-}) => {
   return (
     <CardModal
-      open={open}
+      open={deleteModalOpen}
       onClose={onClose}
       cardProps={{
         sx: {
@@ -87,7 +83,7 @@ const DeleteExperienceModal: React.FC<DeleteExperienceModalProps> = ({
             variant="contained"
             color="error"
             onClick={onDelete}
-            disabled={processingDeletion}
+            disabled={deleteExperience.isLoading}
             data-testid="ExperienceView-DeleteModalDeleteButton"
           >
             Delete

--- a/src/shared/components/side-drawer/EditExperienceModal.tsx
+++ b/src/shared/components/side-drawer/EditExperienceModal.tsx
@@ -1,29 +1,22 @@
 import React from 'react';
 import CardModal from '../../../components/modal/CardModal';
 import ExperienceForm from '../../../components/forms/ExperienceForm';
-import { Experience } from '../../../types/experience';
+import { useLandingPageContext } from '../../../contexts/LandingPageContext';
 
-interface EditExperienceModalProps {
-  open: boolean;
-  onClose: () => void;
-  user: any;
-  experience: Experience;
-  setSelectedExperience: React.Dispatch<Experience>;
-  setExperiences: React.Dispatch<React.SetStateAction<Experience[]>>;
-}
+const EditExperienceModal: React.FC = () => {
+  const {
+    editModalOpen,
+    selectedExperience,
+    user,
+    setSelectedExperience,
+    setExperiences,
+    setEditModalOpen
+  } = useLandingPageContext();
 
-const EditExperienceModal: React.FC<EditExperienceModalProps> = ({
-  open, 
-  onClose,
-  user,
-  experience,
-  setSelectedExperience,
-  setExperiences
-}) => {
   return (
     <CardModal
-      open={open}
-      onClose={onClose}
+      open={editModalOpen}
+      onClose={() => setEditModalOpen(false)}
       cardProps={{
         sx: {
           width: "90%",
@@ -35,7 +28,7 @@ const EditExperienceModal: React.FC<EditExperienceModalProps> = ({
     >
       <ExperienceForm
         mode="edit"
-        existingExperience={experience}
+        existingExperience={selectedExperience!}
         user={user}
         setSelectedExperience={setSelectedExperience}
         setExperiences={setExperiences}

--- a/src/shared/components/side-drawer/ExperiencePreviewList.tsx
+++ b/src/shared/components/side-drawer/ExperiencePreviewList.tsx
@@ -3,21 +3,51 @@ import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import nothingHereIcon from '../../../assets/nothing-here-icon.png';
 import { Box, Button, Typography } from '@mui/material';
-import { Experience } from '../../../types/experience';
+import { useLandingPageContext } from '../../../contexts/LandingPageContext';
 
-interface ExperiencePreviewListProps {
-  experiences: Experience[],
-  setSelectedExperience: React.Dispatch<Experience | null>;
-  hasNextPage: boolean | undefined;
-  fetchNextPage: () => void;
-};
+const ExperiencePreviewList: React.FC = () => {
+  const {
+    experiences,
+    setSelectedExperience,
+    hasNextPage,
+    fetchNextPage
+  } = useLandingPageContext();
 
-const ExperiencePreviewList: React.FC<ExperiencePreviewListProps> = ({
-  experiences,
-  setSelectedExperience,
-  hasNextPage,
-  fetchNextPage
-}) => {
+  const PreviewList = () => {
+    if (!experiences) return null;
+
+    return (
+      <ImageList
+        cols={3}
+        sx={{
+          width: '100%',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+        }}
+        data-testid='ExperiencePreviewList-List'
+      >
+        {experiences.map((experience, index) => (
+          <ImageListItem
+            key={experience._id}
+            onClick={(event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
+              event.stopPropagation();
+              setSelectedExperience(experience);
+            }}
+            sx={{
+              cursor: 'pointer'
+            }}
+            data-testid={`ExperiencePreviewList-ListItem-${index}`}
+          >
+            <img
+              src={`${experience.foodPhotoUrl}?w=248&fit=crop&auto=format`}
+              alt={experience.title}
+              loading="lazy"
+            />
+          </ImageListItem>
+        ))}
+      </ImageList>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -26,7 +56,7 @@ const ExperiencePreviewList: React.FC<ExperiencePreviewListProps> = ({
       }}
       data-testid='ExperiencePreviewList-Container'
     >
-      {!experiences.length && <Box
+      {!experiences?.length && <Box
         sx={{
           paddingTop: '5px',
           width: '100%',
@@ -50,34 +80,7 @@ const ExperiencePreviewList: React.FC<ExperiencePreviewListProps> = ({
           }}
         />
       </Box>}
-      <ImageList
-        cols={3}
-        sx={{
-          width: '100%',
-          paddingBottom: 'env(safe-area-inset-bottom)',
-        }}
-        data-testid='ExperiencePreviewList-List'
-      >
-        {experiences.map((experience, index) => (
-          <ImageListItem
-            key={experience._id}
-            onClick={(event: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
-              event.stopPropagation();
-              setSelectedExperience(experience);
-            }}
-            sx={{
-              cursor: 'pointer'
-            }}
-          data-testid={`ExperiencePreviewList-ListItem-${index}`}
-          >
-            <img
-              src={`${experience.foodPhotoUrl}?w=248&fit=crop&auto=format`}
-              alt={experience.title}
-              loading="lazy"
-            />
-          </ImageListItem>
-        ))}
-      </ImageList>
+      <PreviewList />
       {hasNextPage && (
         <Box
           sx={{

--- a/src/shared/components/side-drawer/ExperienceView/index.tsx
+++ b/src/shared/components/side-drawer/ExperienceView/index.tsx
@@ -16,12 +16,11 @@ import {
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { richTextFromMarkdown } from "@contentful/rich-text-from-markdown";
 import axios from "axios";
+import { useLandingPageContext } from "../../../../contexts/LandingPageContext";
 
 interface ExperienceViewProps {
   experience: Experience;
   onClose: () => void;
-  setEditModalOpen: React.Dispatch<boolean>;
-  setDeleteModalOpen: React.Dispatch<boolean>;
 }
 
 const formatISOToAmericanDate = (isoDate: string) => {
@@ -35,9 +34,7 @@ const formatISOToAmericanDate = (isoDate: string) => {
 
 const ExperienceView: React.FC<ExperienceViewProps> = ({
   experience,
-  onClose,
-  setEditModalOpen,
-  setDeleteModalOpen
+  onClose
 }) => {
   const [ formattedRecipeText, setFormattedRecipeText ] = useState<React.ReactNode | null>(null);
   const { data: currentUser } = useQuery("currentUser", async () => {
@@ -51,6 +48,10 @@ const ExperienceView: React.FC<ExperienceViewProps> = ({
 
     return res.data;
   });
+  const {
+    setEditModalOpen,
+    setDeleteModalOpen
+  } = useLandingPageContext();
 
   const formatMarkdownText = async (text: string) => {
     const formattedText = documentToReactComponents(await richTextFromMarkdown(text));

--- a/src/shared/components/side-drawer/SideDrawer.tsx
+++ b/src/shared/components/side-drawer/SideDrawer.tsx
@@ -6,39 +6,28 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import ExperiencePreviewList from './ExperiencePreviewList';
 import ExperienceView from './ExperienceView';
-import { Experience } from '../../../types/experience';
+import { useLandingPageContext } from '../../../contexts/LandingPageContext';
 
 type Anchor = 'left' | 'right';
 
-interface SideDrawerProps {
-  experiences: Experience[];
-  selectedExperience: Experience | null;
-  setSelectedExperience: React.Dispatch<Experience | null>;
-  hasNextPage: boolean | undefined;
-  fetchNextPage: () => void;
-  setEditModalOpen: React.Dispatch<boolean>;
-  setDeleteModalOpen: React.Dispatch<boolean>;
-  sidebarOpen: boolean;
-  setSidebarOpen: React.Dispatch<boolean>;
-}
-
-const  SideDrawer: React.FC<SideDrawerProps> = ({
-  experiences,
-  selectedExperience,
-  setSelectedExperience,
-  hasNextPage,
-  fetchNextPage,
-  setEditModalOpen,
-  setDeleteModalOpen,
-  sidebarOpen,
-  setSidebarOpen
-}) => {
+const  SideDrawer: React.FC = () => {
   const [sidebar, setSidebar] = useState({
     top: false,
     left: false,
     bottom: false,
     right: false,
   });
+  const {
+    experiences,
+    selectedExperience,
+    setSelectedExperience,
+    setEditModalOpen,
+    setDeleteModalOpen,
+    hasNextPage,
+    fetchNextPage,
+    sidebarOpen,
+    setSidebarOpen
+  } = useLandingPageContext();
 
   const list = (anchor: Anchor) => (
     <Box 
@@ -102,16 +91,9 @@ const  SideDrawer: React.FC<SideDrawerProps> = ({
                   onClose={() => {
                     setSelectedExperience(null);
                   }}
-                  setEditModalOpen={setEditModalOpen}
-                  setDeleteModalOpen={setDeleteModalOpen}
                 />
               </Box>
-              : <ExperiencePreviewList
-                experiences={experiences}
-                setSelectedExperience={setSelectedExperience}
-                hasNextPage={hasNextPage}
-                fetchNextPage={fetchNextPage}
-              />
+              : <ExperiencePreviewList />
           } 
       </Box>
     </Box>

--- a/src/stories/ExperienceView.stories.ts
+++ b/src/stories/ExperienceView.stories.ts
@@ -77,9 +77,7 @@ type Story = StoryObj<typeof meta>;
 export const NotLoggedInAsCreator: Story = {
   args: {
     experience: mockExperience,
-    onClose: () => {},
-    setEditModalOpen: () => {},
-    setDeleteModalOpen: () => {}
+    onClose: () => {}
   },
   parameters: {
     msw: {
@@ -95,9 +93,7 @@ export const NotLoggedInAsCreator: Story = {
 export const LoggedInAsCreator: Story = {
   args: {
     experience: mockExperience,
-    onClose: () => { },
-    setEditModalOpen: () => { },
-    setDeleteModalOpen: () => { }
+    onClose: () => { }
   },
   parameters: {
     msw: {
@@ -113,9 +109,7 @@ export const LoggedInAsCreator: Story = {
 export const CreatorNotFound: Story = {
   args: {
     experience: mockExperience,
-    onClose: () => { },
-    setEditModalOpen: () => { },
-    setDeleteModalOpen: () => { }
+    onClose: () => { }
   },
   parameters: {
     msw: {
@@ -130,9 +124,7 @@ export const CreatorNotFound: Story = {
 export const NonCreatorViewTest: Story = {
   args: {
     experience: mockExperience,
-    onClose: () => { },
-    setEditModalOpen: () => { },
-    setDeleteModalOpen: () => { }
+    onClose: () => { }
   },
   parameters: {
     msw: {
@@ -172,9 +164,7 @@ export const NonCreatorViewTest: Story = {
 export const CreatorViewTest: Story = {
   args: {
     experience: mockExperience,
-    onClose: () => { },
-    setEditModalOpen: () => { },
-    setDeleteModalOpen: () => { }
+    onClose: () => { }
   },
   parameters: {
     msw: {

--- a/src/stories/ExperienceView.stories.ts
+++ b/src/stories/ExperienceView.stories.ts
@@ -2,7 +2,7 @@ import { within, userEvent, waitFor, screen } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Experience } from '../types/experience';
-import { createQueryClientDecorator } from './assets/StorybookDecorators';
+import { createQueryClientDecorator, createLandingPageContextDecorator } from './assets/StorybookDecorators';
 import { QueryClient } from 'react-query';
 import {
   createUserFetchHandler,
@@ -87,7 +87,9 @@ export const NotLoggedInAsCreator: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())]
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ]
 };
 
 export const LoggedInAsCreator: Story = {
@@ -103,7 +105,9 @@ export const LoggedInAsCreator: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())]
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ]
 };
 
 export const CreatorNotFound: Story = {
@@ -118,7 +122,9 @@ export const CreatorNotFound: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())]
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ]
 };
 
 export const NonCreatorViewTest: Story = {
@@ -134,7 +140,9 @@ export const NonCreatorViewTest: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())],
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -174,7 +182,9 @@ export const CreatorViewTest: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())],
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/src/stories/MapUIOverlay.stories.tsx
+++ b/src/stories/MapUIOverlay.stories.tsx
@@ -3,9 +3,9 @@ import { fn } from '@storybook/test';
 import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
 import { QueryClient } from 'react-query';
-import { redirectToLogin } from '../api/helpers';
-import { createQueryClientDecorator } from './assets/StorybookDecorators';
+import { createQueryClientDecorator, createLandingPageContextDecorator} from './assets/StorybookDecorators';
 import { createUserFetchHandler } from './util/mswHandlers';
+import { LandingPageContextProvider } from '../contexts/LandingPageContext';
 import MapUIOverlay from '../components/MapUIOverlay';
 
 const mockUser = {
@@ -25,16 +25,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const LoggedIn: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        fetchUser: [createUserFetchHandler(200)]
+      }
+    }
+  },
   args: {
     redirectToLogin: fn(),
   },
-  decorators: [createQueryClientDecorator(new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 3 * 1000
-      }
-    }
-  }))]
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ]
 };
 
 export const LoggedOut: Story = {
@@ -48,20 +51,25 @@ export const LoggedOut: Story = {
       }
     }
   },
-  decorators: [createQueryClientDecorator(new QueryClient())]
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ]
 };
 
 export const CreateExperienceButtonLoggedInTest: Story = {
   args: {
     redirectToLogin: fn()
   },
-  decorators: [createQueryClientDecorator(new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 60 * 1000
+  parameters: {
+    msw: {
+      handlers: {
+        fetchUser: [createUserFetchHandler(200)]
       }
     }
-  }))],
+  },
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
   play: async () => {
     await waitFor(() => {
       expect(screen.getByTestId("MapUIOverlay-CreateExperienceButton-LoggedIn")).toBeInTheDocument();
@@ -89,7 +97,16 @@ export const CreateExperienceButtonLoggedOutTest: Story = {
   args: {
     redirectToLogin: fn()
   },
-  decorators: [createQueryClientDecorator(new QueryClient())],
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
+  parameters: {
+    msw: {
+      handlers: {
+        fetchUser: [createUserFetchHandler(500)]
+      }
+    }
+  },
   play: async ({ args }) => {
     expect(screen.getByTestId("MapUIOverlay-CreateExperienceButton-LoggedOut")).toBeInTheDocument();
     expect(screen.getByTestId("LocationSearch-InputField")).toBeInTheDocument();
@@ -105,13 +122,16 @@ export const TestBugReport: Story = {
   args: {
     redirectToLogin: fn()
   },
-  decorators: [createQueryClientDecorator(new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 3 * 1000
+  parameters: {
+    msw: {
+      handlers: {
+        fetchUser: [createUserFetchHandler(200)]
       }
     }
-  }))],
+  },
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
   play: async ({ args }) => {
     expect(screen.getByTestId("MapUIOverlay-ReportBugButton")).toBeInTheDocument();
     expect(screen.queryByTestId("MapUIOverlay-BugReportModal")).not.toBeInTheDocument();

--- a/src/stories/MapUIOverlay.stories.tsx
+++ b/src/stories/MapUIOverlay.stories.tsx
@@ -27,7 +27,6 @@ type Story = StoryObj<typeof meta>;
 export const LoggedIn: Story = {
   args: {
     redirectToLogin: fn(),
-    user: mockUser
   },
   decorators: [createQueryClientDecorator(new QueryClient({
     defaultOptions: {
@@ -41,7 +40,6 @@ export const LoggedIn: Story = {
 export const LoggedOut: Story = {
   args: {
     redirectToLogin: fn(),
-    user: mockUser
   },
   parameters: {
     msw: {
@@ -55,8 +53,7 @@ export const LoggedOut: Story = {
 
 export const CreateExperienceButtonLoggedInTest: Story = {
   args: {
-    redirectToLogin: fn(),
-    user: mockUser
+    redirectToLogin: fn()
   },
   decorators: [createQueryClientDecorator(new QueryClient({
     defaultOptions: {
@@ -106,8 +103,7 @@ export const CreateExperienceButtonLoggedOutTest: Story = {
 
 export const TestBugReport: Story = {
   args: {
-    redirectToLogin: fn(),
-    user: mockUser
+    redirectToLogin: fn()
   },
   decorators: [createQueryClientDecorator(new QueryClient({
     defaultOptions: {

--- a/src/stories/SideDrawer.stories.ts
+++ b/src/stories/SideDrawer.stories.ts
@@ -1,7 +1,7 @@
 import { userEvent, waitFor, screen } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
-import { createQueryClientDecorator } from './assets/StorybookDecorators';
+import { createQueryClientDecorator, createLandingPageContextDecorator } from './assets/StorybookDecorators';
 import { QueryClient } from 'react-query';
 import { Experience } from '../types/experience';
 import SideDrawer from '../shared/components/side-drawer/SideDrawer';
@@ -56,7 +56,10 @@ export const Base: Story = {
     fetchNextPage: () => {},
     sidebarOpen: false,
     setSidebarOpen: () => {}
-  }
+  },
+  decorators: [
+    createLandingPageContextDecorator(new QueryClient())
+  ],
 };
 
 // export const OpenClosedTest: Story = {

--- a/src/stories/assets/StorybookDecorators.tsx
+++ b/src/stories/assets/StorybookDecorators.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "react-query";
-import { BrowserRouter } from "react-router-dom";
+import { LandingPageContextProvider } from "../../contexts/LandingPageContext";
 
 export const createQueryClientDecorator = (queryClient: QueryClient) => {
   return (storyFn: any) => {
@@ -19,4 +19,16 @@ export const QueryClientDecorator = (storyFn: any) => {
       {storyFn}
     </QueryClientProvider>
   );
+};
+
+export const createLandingPageContextDecorator = (queryClient: QueryClient) => {
+  return (storyFn: any) => {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <LandingPageContextProvider>
+          {storyFn()}
+        </LandingPageContextProvider>
+      </QueryClientProvider>
+    );
+  };
 };


### PR DESCRIPTION
Moved state variables out of `LandingPage` component and into a context for consumption by all child components.